### PR TITLE
SCOUT-2135 Isolation Distance is not accurate around the whole feature

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "geos",
+        "repositoryURL": "https://github.com/GEOSwift/geos.git",
+        "state": {
+          "branch": null,
+          "revision": "f510e634c822116fca615064d889300dba40d761",
+          "version": "8.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/GeospatialSwift/API/GeoJson/Object/MultiPolygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/MultiPolygon.swift
@@ -97,7 +97,7 @@ extension GeoJson.MultiPolygon {
         return []
     }
     
-    public func buffer(by distance: Double, isEarthCoordinates: Bool = false) throws -> GeoJson.MultiPolygon {
+    public func buffer(distance: Double, isEarthCoordinates: Bool = false) throws -> GeoJson.MultiPolygon {
         do {
             let polygons: [GeoJson.Polygon] = try geoJsonPolygons.map { polygon in
                 return try polygon.buffer(distance: distance, isEarthCoordinates: isEarthCoordinates)

--- a/Sources/GeospatialSwift/API/GeoJson/Object/MultiPolygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/MultiPolygon.swift
@@ -97,7 +97,7 @@ extension GeoJson.MultiPolygon {
         return []
     }
     
-    public func buffer(distance: Double, isEarthCoordinates: Bool = false) throws -> GeoJson.MultiPolygon {
+    public func buffer(distance: Double, isEarthCoordinates: Bool = true) throws -> GeoJson.MultiPolygon {
         do {
             let polygons: [GeoJson.Polygon] = try geoJsonPolygons.map { polygon in
                 return try polygon.buffer(distance: distance, isEarthCoordinates: isEarthCoordinates)

--- a/Sources/GeospatialSwift/API/GeoJson/Object/MultiPolygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/MultiPolygon.swift
@@ -97,10 +97,10 @@ extension GeoJson.MultiPolygon {
         return []
     }
     
-    public func buffer(by width: Double) throws -> GeoJson.MultiPolygon {
+    public func buffer(by distance: Double, isEarthCoordinates: Bool = false) throws -> GeoJson.MultiPolygon {
         do {
             let polygons: [GeoJson.Polygon] = try geoJsonPolygons.map { polygon in
-                return try polygon.buffer(by: width)
+                return try polygon.buffer(distance: distance, isEarthCoordinates: isEarthCoordinates)
             }
             
             return GeoJson.MultiPolygon(polygons: polygons)

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -204,7 +204,7 @@ extension GeoJson.Polygon {
         var polygon = self
         var distance: Double = distance
         
-        if isEarthCoordinates, if let polygonLatitude = polygon.mainRing.points.first?.latitude { {
+        if isEarthCoordinates, let polygonLatitude = polygon.mainRing.points.first?.latitude {
                 // Convert Location distance into 2d Mercator distance
                 distance = distance / cos(polygonLatitude * .pi / 180)
             

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -206,11 +206,11 @@ extension GeoJson.Polygon {
         
         if isEarthCoordinates {
             let externalPoints = polygon.mainRing.points
-            let originalDistanceBetweenPoints = externalPoints[0].distance(to: externalPoints[1])
+            let originalDistanceBetweenPoints = externalPoints[0].distance(toOther: externalPoints[1])
             let projectedPolygon = mercatorProjectedPolygon(isInverse: false)
             polygon = projectedPolygon
             let projectedExternalPoints = projectedPolygon.mainRing.points
-            let projectedlDistanceBetweenPoints = projectedExternalPoints[0].distance(to: projectedExternalPoints[1])
+            let projectedlDistanceBetweenPoints = projectedExternalPoints[0].distance(toOther: projectedExternalPoints[1])
             
             distance = distance * (projectedlDistanceBetweenPoints / originalDistanceBetweenPoints)
         }

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -194,24 +194,44 @@ extension GeoJson.Polygon {
     
     /// Calculates the buffer (a polygon being the spatial point set collection within a specified maximum distance from a geometry) of a geometry.
     /// - Parameters:
-    ///    - distance: width in latitude degree (uom)
+    ///    - distance: distance in (meeters if isEarthCoordinates) or any other
     ///    - uom: Unit of measurement (m/ft)
     ///    - Returns: buffered Polygon Geometry
     
-    public func buffer(by width: Double) throws -> GeoJson.Polygon {
+    public func buffer(distance: Double, isEarthCoordinates: Bool = true) throws -> GeoJson.Polygon {
         let context = try GEOSContext()
+        
+        var polygon = self
+        var distance = distance
+        
+        if isEarthCoordinates {
+            let externalPoints = polygon.mainRing.points
+            let originalDistanceBetweenPoints = externalPoints[0].distance(to: externalPoints[1])
+            let projectedPolygon = mercatorProjectedPolygon(isInverse: false)
+            let projectedExternalPoints = projectedPolygon.mainRing.points
+            let projectedlDistanceBetweenPoints = projectedExternalPoints[0].distance(to: projectedExternalPoints[1])
+            
+            distance = distance * (projectedlDistanceBetweenPoints / originalDistanceBetweenPoints)
+        }
         
         let geosObject = try self.geosObject(with: context)
         // the last parameter in GEOSBuffer_r is called `quadsegs` and in other places in GEOS, it defaults to
         // 8, which seems to produce an "expected" result. See https://github.com/GEOSwift/GEOSwift/issues/216
         //
         // returns nil on exception
-        guard let resultPointer = GEOSBuffer_r(context.handle, geosObject.pointer, width, 8) else {
+        guard let resultPointer = GEOSBuffer_r(context.handle, geosObject.pointer, distance, 8) else {
             throw GEOSError.libraryError(errorMessages: context.errors)
         }
+        
         do {
             let geosObject = GEOSObject(context: context, pointer: resultPointer)
-            return try GeoJson.Polygon(geosObject: geosObject)
+            let resultPolygon = try GeoJson.Polygon(geosObject: geosObject)
+            
+            if isEarthCoordinates {
+                return resultPolygon.mercatorProjectedPolygon(isInverse: true)
+            } else {
+                return resultPolygon
+            }
         } catch {
             throw error
         }
@@ -227,6 +247,35 @@ extension GeoJson.Polygon {
         let validateLinearRings = linearRingsCoordinatesJson.reduce(nil) { $0 + GeoJson.LinearRing.validate(coordinatesJson: $1) }
         
         return validateLinearRings.flatMap { .init(reason: "Invalid LinearRing(s) in Polygon") + $0 }
+    }
+    
+    internal func mercatorProjectedPolygon(isInverse: Bool) -> GeoJson.Polygon {
+        let mainRingpoints = mainRing.points.map { point in
+            let projection = isInverse ? point.mercatorInverseProjection : point.mercatorProjection
+            return GeoJson.Point(
+                longitude: projection.longitude,
+                latitude: projection.latitude,
+                altitude: projection.altitude
+            )
+        }
+        
+        let negativeRings = negativeRings.compactMap { line in
+            let projectedPoints = line.points.map { point in
+                let projection = point.mercatorProjection
+                return GeoJson.Point(
+                    longitude: projection.longitude,
+                    latitude: projection.latitude,
+                    altitude: projection.altitude
+                )
+            }
+            
+            return GeoJson.LineString(points: projectedPoints)
+        }
+        
+        return GeoJson.Polygon(
+            mainRing: GeoJson.LineString(points: mainRingpoints),
+            negativeRings: negativeRings
+        )
     }
 }
 

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -204,16 +204,11 @@ extension GeoJson.Polygon {
         var polygon = self
         var distance: Double = distance
         
-        print("orinal distance: \(distance)")
-        
-        if isEarthCoordinates {
-            if let polygonLatitude = polygon.mainRing.points.first?.latitude {
-                // Take any oryginal polygon any point latitude to convert distance into Mercator distance
-                let distanceAfterMercatorProjection = distance / cos(polygonLatitude * .pi / 180)
-                print("distanceAfterMercatorProjection: \(distanceAfterMercatorProjection)")
-                distance = distanceAfterMercatorProjection
-            }
+        if isEarthCoordinates, if let polygonLatitude = polygon.mainRing.points.first?.latitude { {
+                // Convert Location distance into 2d Mercator distance
+                distance = distance / cos(polygonLatitude * .pi / 180)
             
+            // For Earth Coordinate we need convert polygon into Mercator projectd 2d coordinate system
             polygon = mercatorProjectedPolygon(isInverse: false)
         }
         
@@ -231,6 +226,7 @@ extension GeoJson.Polygon {
             let resultPolygon = try GeoJson.Polygon(geosObject: geosObject)
             
             if isEarthCoordinates {
+                // Convert back 2d coordinate system into cylindrical map projection
                 return resultPolygon.mercatorProjectedPolygon(isInverse: true)
             } else {
                 return resultPolygon

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -204,15 +204,22 @@ extension GeoJson.Polygon {
         var polygon = self
         var distance = distance
         
+        print("orinal distance: \(distance)")
+        
         if isEarthCoordinates {
-            let externalPoints = polygon.mainRing.points
-            let originalDistanceBetweenPoints = externalPoints[0].distance(toOther: externalPoints[1])
-            let projectedPolygon = mercatorProjectedPolygon(isInverse: false)
-            polygon = projectedPolygon
-            let projectedExternalPoints = projectedPolygon.mainRing.points
-            let projectedlDistanceBetweenPoints = projectedExternalPoints[0].distance(toOther: projectedExternalPoints[1])
             
-            distance = distance * (projectedlDistanceBetweenPoints / originalDistanceBetweenPoints)
+            func distanceAfterMercatorProjection(distance: Double, atLatitude latitude: Double) -> Double {
+                return 
+            }
+            
+            let polygonLatitude = polygon.mainRing.points.first?.latitude {
+                // Take any oryginal polygon any point latitude to convert distance into Mercator distance
+                let distanceAfterMercatorProjection  = distance / cos(latitude * .pi / 180)
+                print("distanceAfterMercatorProjection: \(distanceAfterMercatorProjection)")
+                distance = distanceAfterMercatorProjection
+            }
+            
+            polygon = mercatorProjectedPolygon(isInverse: false)
         }
         
         let geosObject = try polygon.geosObject(with: context)

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -208,13 +208,14 @@ extension GeoJson.Polygon {
             let externalPoints = polygon.mainRing.points
             let originalDistanceBetweenPoints = externalPoints[0].distance(to: externalPoints[1])
             let projectedPolygon = mercatorProjectedPolygon(isInverse: false)
+            polygon = projectedPolygon
             let projectedExternalPoints = projectedPolygon.mainRing.points
             let projectedlDistanceBetweenPoints = projectedExternalPoints[0].distance(to: projectedExternalPoints[1])
             
             distance = distance * (projectedlDistanceBetweenPoints / originalDistanceBetweenPoints)
         }
         
-        let geosObject = try self.geosObject(with: context)
+        let geosObject = try polygon.geosObject(with: context)
         // the last parameter in GEOSBuffer_r is called `quadsegs` and in other places in GEOS, it defaults to
         // 8, which seems to produce an "expected" result. See https://github.com/GEOSwift/GEOSwift/issues/216
         //

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -202,19 +202,14 @@ extension GeoJson.Polygon {
         let context = try GEOSContext()
         
         var polygon = self
-        var distance = distance
+        var distance: Double = distance
         
         print("orinal distance: \(distance)")
         
         if isEarthCoordinates {
-            
-            func distanceAfterMercatorProjection(distance: Double, atLatitude latitude: Double) -> Double {
-                return 
-            }
-            
-            let polygonLatitude = polygon.mainRing.points.first?.latitude {
+            if let polygonLatitude = polygon.mainRing.points.first?.latitude {
                 // Take any oryginal polygon any point latitude to convert distance into Mercator distance
-                let distanceAfterMercatorProjection  = distance / cos(latitude * .pi / 180)
+                let distanceAfterMercatorProjection = distance / cos(polygonLatitude * .pi / 180)
                 print("distanceAfterMercatorProjection: \(distanceAfterMercatorProjection)")
                 distance = distanceAfterMercatorProjection
             }

--- a/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
+++ b/Sources/GeospatialSwift/API/GeoJson/Object/Polygon.swift
@@ -249,7 +249,7 @@ extension GeoJson.Polygon {
     }
     
     internal func mercatorProjectedPolygon(isInverse: Bool) -> GeoJson.Polygon {
-        let mainRingpoints = mainRing.points.map { point in
+        let mainRingPoints = mainRing.points.map { point in
             let projection = isInverse ? point.mercatorInverseProjection : point.mercatorProjection
             return GeoJson.Point(
                 longitude: projection.longitude,
@@ -272,7 +272,7 @@ extension GeoJson.Polygon {
         }
         
         return GeoJson.Polygon(
-            mainRing: GeoJson.LineString(points: mainRingpoints),
+            mainRing: GeoJson.LineString(points: mainRingPoints),
             negativeRings: negativeRings
         )
     }

--- a/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
+++ b/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
@@ -1,3 +1,5 @@
+import CoreLocation
+
 public protocol GeodesicPoint {
     var longitude: Double { get }
     var latitude: Double { get }
@@ -7,6 +9,42 @@ public protocol GeodesicPoint {
 public extension GeodesicPoint {
     var degreesToRadians: GeodesicPoint { SimplePoint(longitude: longitude.degreesToRadians, latitude: latitude.degreesToRadians, altitude: altitude) }
     var radiansToDegrees: GeodesicPoint { SimplePoint(longitude: longitude.radiansToDegrees, latitude: latitude.radiansToDegrees, altitude: altitude) }
+}
+
+public extension GeodesicPoint {
+    
+    var mercatorProjection: GeodesicPoint {
+        let radius: Double = 6378137.0 // Earth radius
+
+        let latRad = self.latitude * .pi / 180.0
+        let lonRad = self.longitude * .pi / 180.0
+
+        let x = radius * lonRad
+        let y = radius * log(tan(.pi / 4.0 + latRad / 2.0))
+
+        return SimplePoint(longitude: x, latitude: y, altitude: altitude)
+    }
+    
+    var mercatorInverseProjection: GeodesicPoint {
+        let R = 6378137.0
+        let x = self.longitude
+        let y = self.latitude
+        
+        let lambda = x / R
+        
+        let phi = 2 * atan(exp(y / R)) - .pi / 2
+        
+        let latitude = phi * 180.0 / .pi
+        let longitude = lambda * 180.0 / .pi
+        
+        return SimplePoint(longitude: longitude, latitude: latitude, altitude: altitude)
+    }
+    
+    func distance(to point: GeodesicPoint) -> Double {
+        let lhs = CLLocation(latitude: self.latitude, longitude: self.longitude)
+        let rhs = CLLocation(latitude: point.latitude, longitude: point.longitude)
+        return rhs.distance(from: lhs)
+    }
 }
 
 public struct SimplePoint: GeodesicPoint {

--- a/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
+++ b/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
@@ -40,11 +40,11 @@ public extension GeodesicPoint {
         return SimplePoint(longitude: longitude, latitude: latitude, altitude: altitude)
     }
     
-    func distance(toOther point: GeodesicPoint) -> Double {
-        let lhs = CLLocation(latitude: self.latitude, longitude: self.longitude)
-        let rhs = CLLocation(latitude: point.latitude, longitude: point.longitude)
-        return rhs.distance(from: lhs)
-    }
+//    func distance(toOther point: GeodesicPoint) -> Double {
+//        let lhs = CLLocation(latitude: self.latitude, longitude: self.longitude)
+//        let rhs = CLLocation(latitude: point.latitude, longitude: point.longitude)
+//        return rhs.distance(from: lhs)
+//    }
 }
 
 public struct SimplePoint: GeodesicPoint {

--- a/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
+++ b/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
@@ -40,7 +40,7 @@ public extension GeodesicPoint {
         return SimplePoint(longitude: longitude, latitude: latitude, altitude: altitude)
     }
     
-    func distance(to point: GeodesicPoint) -> Double {
+    func distance(toOther point: GeodesicPoint) -> Double {
         let lhs = CLLocation(latitude: self.latitude, longitude: self.longitude)
         let rhs = CLLocation(latitude: point.latitude, longitude: point.longitude)
         return rhs.distance(from: lhs)

--- a/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
+++ b/Sources/GeospatialSwift/API/Geodesic/GeodesicPoint.swift
@@ -1,4 +1,4 @@
-import CoreLocation
+import Foundation
 
 public protocol GeodesicPoint {
     var longitude: Double { get }
@@ -39,12 +39,6 @@ public extension GeodesicPoint {
         
         return SimplePoint(longitude: longitude, latitude: latitude, altitude: altitude)
     }
-    
-//    func distance(toOther point: GeodesicPoint) -> Double {
-//        let lhs = CLLocation(latitude: self.latitude, longitude: self.longitude)
-//        let rhs = CLLocation(latitude: point.latitude, longitude: point.longitude)
-//        return rhs.distance(from: lhs)
-//    }
 }
 
 public struct SimplePoint: GeodesicPoint {


### PR DESCRIPTION
# 🦉

## Issue ticket link:
[SCOUT-2135](https://monsanto.aha.io/features/SCOUT-2135)

## Description:
9/10 Workshop: Will need to investigate packages that we can use to draw this. Geometry is drawn dynamically so won't help to link with PFO on this since we draw ourselves on-device.

When creating a Production Area, Isolation distance is an option to add. When adding an Isolation distance, if you measure the distance in Scout from the boundary to the edge of the iso, it is not accurate to the actual distance inputted when saving. PFO appears to be accurate 
Images uploaded below are of my field in NP showing the issue. 

## 🤷 Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## 📝 Checklist:
- [ ] I removed all necessary TO DO and debug snippets
- [x] I have added comments, particularly in hard-to-understand areas 
- [ ] I added .localized to all new localizable strings and added localization keys at [Internalization Tool](https://devtools.bayer.com/translation/keys/scout-mobile)

### Screenshots/video (if appropriate):
